### PR TITLE
Disable globalization on compile - linux

### DIFF
--- a/Collector/Collector.csproj
+++ b/Collector/Collector.csproj
@@ -7,6 +7,7 @@
     <ApplicationIcon>packet.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishReadyToRunShowWarnings>false</PublishReadyToRunShowWarnings>


### PR DESCRIPTION
Some linux systems will fail to run because of a "Couldn't find a valid ICU package". We do not need Globalization support, so disabling it should allow for it to run.